### PR TITLE
Display a list of movies sorted by year and then by title

### DIFF
--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -1,20 +1,22 @@
-import moment from 'moment'
 import movies from './movies'
 
 
 export function getPopularMovies () {
-  //
-  // movies contains the results of two API requests
-  //
+  // Combine an array of arrays into a single array.
+  const combinedResults = [...movies[0], ...movies[1]];
+  combinedResults.forEach((el) => {
+    const { title } = el;
+    // Extract year that is at the end of title inside parenthesis and add it to new releaseYear attribute.
+    // Note: I was thinking of extracting year value from releaseDate but it doesn't seem to make sense
+    // since let's say for Forrest Gump it would display 1945 but the movie was released in 1994, that's
+    // why I decided to extract from title.
+    el.releaseYear = parseInt(title.substring((title.length - 5), (title.length - 1)));
+  });
 
-  //
-  // 1. combine the results of these requests
-  // 2. sort the results FIRST by year THEN by title
-  // 3. each movie object in the results needs a releaseYear attribute added
-  //    this is used in src/components/movies-list.js line 25
-  //
-
-  const combinedResults = []
+  // Sort by year then by title.
+  // First compare years. If the years are not equal then sort by year and ignore comparing titles
+  // If the years are equal then compare titles to see if one title comes before another alphabetically
+  combinedResults.sort((a, b) => a.releaseYear - b.releaseYear  ||  a.title.localeCompare(b.title));
 
   return {
     type: 'GET_MOVIES_SUCCESS',


### PR DESCRIPTION
User should be able to see a list of 200 movies, both 4-star and 5-star, sorted by year and then by title.

Acceptance criteria:
* User clicks the “get movies” button 
* User sees a list of movies sorted primarily by year, secondarily by title. All in one list. 
* All columns in the display are populated

Specific Tasks that have been implemented:
* Combined movie results from 2 APIs into 1
* Added release year for each movie result by extracting it from movie title
* Sorted movie result by year and then title by comparing years first. If the years are not equal then sort by year and ignore comparing titles. If the years are equal then compare titles to see if one title comes before another alphabetically

@kjs3 please review